### PR TITLE
Integration with audio-tempo-changer.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "audio-feeder",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "description": "Abstraction for streaming raw PCM audio in browser via Web Audio API.",
   "main": "dist/AudioFeeder.js",
   "repository": {
@@ -29,6 +29,7 @@
     "webpack.config.js"
   ],
   "devDependencies": {
+    "audio-tempo-changer.js": "^0.2.0",
     "eslint": "^5.13.0",
     "file-loader": "^0.8.5",
     "grunt": "^1.0.1",
@@ -36,6 +37,7 @@
     "grunt-eslint": "^18.1.0",
     "grunt-webpack": "^1.0.11",
     "webpack": "^1.12.2",
+    "webpack-cli": "^3.3.2",
     "webpack-dev-server": "^3.1.14"
   },
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,8 @@ and is suitable for use in custom audio and video playback.
 * dynamicaudio.as and some Flash-related bits are based on code under BSD license, (c) 2010 Ben Firshman
 
 ## Updates
+* 0.4.21 - 2019-05-28
+    * Included audio-tempo-changer to allow changing tempo of audio via .tempo attribute
 * 0.4.20 - 2019-05-17
     * Fix for running Flash path when embedded into strict mode
 * 0.4.19 - 2019-03-24

--- a/src/demo.js
+++ b/src/demo.js
@@ -11,13 +11,8 @@ module.exports = function demo() {
     channels = 1,
     rate = 48000,
     sampleCounter = 0,
-    feeder = new AudioFeeder();
-
-  start.disabled = true;
-  feeder.init(channels, rate);
-  feeder.waitUntilReady(function() {
-    start.disabled = false;
-  });
+    feeder = new AudioFeeder(),
+    initialized = false;
 
   function bufferSineWave(time) {
     var freq = 261, // middle C
@@ -38,8 +33,18 @@ module.exports = function demo() {
     start.disabled = true;
     stop.disabled = false;
 
-    bufferSineWave(1); // pre-buffer 1s
-    feeder.start();
+    var startFn = function() {
+      bufferSineWave(1); // pre-buffer 1s
+      feeder.tempo = 0.3;
+      feeder.start();
+    };
+
+    if (!initialized) {
+      feeder.init(channels, rate);
+      feeder.waitUntilReady(startFn);
+      initialized = true;
+    } else startFn();
+
   });
 
   stop.addEventListener('click', function() {


### PR DESCRIPTION
Hence fixing https://github.com/brion/audio-feeder/issues/32

@brion I decided to rename my phase vocoder package as audio-tempo-changer.js and the class to AudioTempoChanger to make it clearer for anyone looking at audio-feeder what it is (as phase vocoder is a technical term not everyone knows). 

Also bumped the version number so ogv.js package.json could be updated (and wrote the corresponding readme.md line). Hopefully that's ok. 

The corresponding PR for ogv.js is at https://github.com/brion/ogv.js/pull/522